### PR TITLE
Bundles the Julia extracted folder instead of compressed zip

### DIFF
--- a/.erb/scripts/beforePack.js
+++ b/.erb/scripts/beforePack.js
@@ -1,0 +1,31 @@
+const rimraf = require('rimraf');
+const process = require('process');
+const path = require('node:path');
+const fs = require('fs');
+const unzip = require('extract-zip');
+const chalk = require('chalk');
+
+const assetPath = path.join(__dirname, '../..', 'assets');
+
+exports.default = async (context) => {
+  const files = fs.readdirSync(assetPath);
+  const juliaFolderIdx = files.findIndex(
+    (v) => v.startsWith('julia-') && !v.endsWith('zip')
+  );
+  if (juliaFolderIdx !== -1) {
+    console.log(chalk.grey('\tDeleted Julia folder'));
+    rimraf.sync(path.join(assetPath, files[juliaFolderIdx]), {
+      recursive: true,
+      force: true,
+    });
+  }
+  const juliaIdx = files.findIndex(
+    (v) => v.startsWith('julia-') && v.endsWith('zip')
+  );
+  let zip = files[juliaIdx];
+  const nameInitial = zip.replace('-win64.zip', '');
+  console.log(chalk.grey('\tExtracting:', zip));
+  zip = path.join(assetPath, zip);
+  await unzip(zip, { dir: assetPath });
+  console.log(chalk.grey('\tExtracted new Julia folder'));
+};

--- a/.erb/scripts/clean.js
+++ b/.erb/scripts/clean.js
@@ -36,4 +36,4 @@ const deleteJuliaFolder = () => {
   }
 };
 
-deleteJuliaFolder();
+// deleteJuliaFolder();

--- a/.erb/scripts/clean.js
+++ b/.erb/scripts/clean.js
@@ -2,7 +2,6 @@
 import rimraf from 'rimraf';
 import process from 'process';
 import path from 'node:path';
-import fs from 'fs';
 import webpackPaths from '../configs/webpack.paths';
 
 const args = process.argv.slice(2);
@@ -18,22 +17,3 @@ args.forEach((x) => {
     rimraf.sync(pathToRemove);
   }
 });
-
-const deleteJuliaFolder = () => {
-  const assetPath = path.join(webpackPaths.rootPath, 'assets');
-  const files = fs.readdirSync(assetPath);
-  const juliaIdx = files.findIndex(
-    (v) => v.startsWith('julia-') && !v.endsWith('zip')
-  );
-  if (juliaIdx !== -1) {
-    console.log(
-      'Deleted Julia folder, hence not bundling it, only zip is bundled.'
-    );
-    rimraf.sync(path.join(assetPath, files[juliaIdx]), {
-      recursive: true,
-      force: true,
-    });
-  }
-};
-
-// deleteJuliaFolder();

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "extract-zip": "^2.0.1",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
-        "react-router-dom": "^6.3.0",
+        "react-loader-spinner": "^5.1.5",
         "yargs": "^17.5.1"
       },
       "devDependencies": {
@@ -24,6 +24,7 @@
         "@teamsupercell/typings-for-css-modules-loader": "^2.5.1",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.2.0",
+        "@types/detect-port": "^1.3.2",
         "@types/jest": "^27.5.1",
         "@types/node": "17.0.33",
         "@types/react": "^18.0.9",
@@ -598,6 +599,7 @@
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.3.tgz",
       "integrity": "sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==",
+      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -1924,6 +1926,12 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/detect-port": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/detect-port/-/detect-port-1.3.2.tgz",
+      "integrity": "sha512-xxgAGA2SAU4111QefXPSp5eGbDm/hW6zhvYl9IeEPZEry9F4d66QAHm5qpUXjb6IsevZV/7emAEx5MhP6O192g==",
+      "dev": true
     },
     "node_modules/@types/eslint": {
       "version": "8.4.1",
@@ -4218,9 +4226,9 @@
       "dev": true
     },
     "node_modules/ci-info": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
-      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
+      "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
       "dev": true
     },
     "node_modules/cjs-module-lexer": {
@@ -4451,9 +4459,9 @@
       }
     },
     "node_modules/compress-brotli": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/compress-brotli/-/compress-brotli-1.3.6.tgz",
-      "integrity": "sha512-au99/GqZtUtiCBliqLFbWlhnCxn+XSYjwZ77q6mKN4La4qOXDoLVPZ50iXr0WmAyMxl8yqoq3Yq4OeQNPPkyeQ==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/compress-brotli/-/compress-brotli-1.3.8.tgz",
+      "integrity": "sha512-lVcQsjhxhIXsuupfy9fmZUFtAIdBmXA7EGY6GBdgZ++qkM9zG4YFT8iU7FoBxzryNDMOpD1HIFHUSX4D87oqhQ==",
       "dev": true,
       "dependencies": {
         "@types/json-buffer": "~3.0.0",
@@ -8835,14 +8843,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/history": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
-      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -9063,9 +9063,9 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dev": true,
       "dependencies": {
         "agent-base": "6",
@@ -12091,9 +12091,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.2.tgz",
-      "integrity": "sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -13840,6 +13840,15 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/react-loader-spinner": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/react-loader-spinner/-/react-loader-spinner-5.1.5.tgz",
+      "integrity": "sha512-kHSBa3pNPNzd3UGOiOsHCC33qx5bZA7IHKau+YSTVn36Jib4eBVx/TNMggudbzW5CTnRCbP5bnYU4ACAX3mA6g==",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz",
@@ -13847,30 +13856,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-router": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
-      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
-      "dependencies": {
-        "history": "^5.2.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
-      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
-      "dependencies": {
-        "history": "^5.2.0",
-        "react-router": "6.3.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-shallow-renderer": {
@@ -13977,7 +13962,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.1",
@@ -17316,6 +17302,7 @@
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.3.tgz",
       "integrity": "sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -18370,6 +18357,12 @@
       "requires": {
         "@types/ms": "*"
       }
+    },
+    "@types/detect-port": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/detect-port/-/detect-port-1.3.2.tgz",
+      "integrity": "sha512-xxgAGA2SAU4111QefXPSp5eGbDm/hW6zhvYl9IeEPZEry9F4d66QAHm5qpUXjb6IsevZV/7emAEx5MhP6O192g==",
+      "dev": true
     },
     "@types/eslint": {
       "version": "8.4.1",
@@ -20193,9 +20186,9 @@
       "dev": true
     },
     "ci-info": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
-      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
+      "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
       "dev": true
     },
     "cjs-module-lexer": {
@@ -20370,9 +20363,9 @@
       "dev": true
     },
     "compress-brotli": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/compress-brotli/-/compress-brotli-1.3.6.tgz",
-      "integrity": "sha512-au99/GqZtUtiCBliqLFbWlhnCxn+XSYjwZ77q6mKN4La4qOXDoLVPZ50iXr0WmAyMxl8yqoq3Yq4OeQNPPkyeQ==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/compress-brotli/-/compress-brotli-1.3.8.tgz",
+      "integrity": "sha512-lVcQsjhxhIXsuupfy9fmZUFtAIdBmXA7EGY6GBdgZ++qkM9zG4YFT8iU7FoBxzryNDMOpD1HIFHUSX4D87oqhQ==",
       "dev": true,
       "requires": {
         "@types/json-buffer": "~3.0.0",
@@ -23669,14 +23662,6 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
-    "history": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
-      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
-      "requires": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
     "hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -23844,9 +23829,9 @@
       }
     },
     "https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dev": true,
       "requires": {
         "agent-base": "6",
@@ -26101,9 +26086,9 @@
       }
     },
     "nanoid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.2.tgz",
-      "integrity": "sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true
     },
     "natural-compare": {
@@ -27339,28 +27324,17 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "react-loader-spinner": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/react-loader-spinner/-/react-loader-spinner-5.1.5.tgz",
+      "integrity": "sha512-kHSBa3pNPNzd3UGOiOsHCC33qx5bZA7IHKau+YSTVn36Jib4eBVx/TNMggudbzW5CTnRCbP5bnYU4ACAX3mA6g==",
+      "requires": {}
+    },
     "react-refresh": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz",
       "integrity": "sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==",
       "dev": true
-    },
-    "react-router": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
-      "integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
-      "requires": {
-        "history": "^5.2.0"
-      }
-    },
-    "react-router-dom": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
-      "integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
-      "requires": {
-        "history": "^5.2.0",
-        "react-router": "6.3.0"
-      }
     },
     "react-shallow-renderer": {
       "version": "16.15.0",
@@ -27450,7 +27424,8 @@
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
     },
     "regexp.prototype.flags": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "start": "ts-node ./.erb/scripts/check-port-in-use.js && npm run start:renderer",
     "start:main": "cross-env NODE_ENV=development electronmon -r ts-node/register/transpile-only .",
     "start:preload": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.preload.dev.ts",
-    "start:renderer": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack serve --config ./.erb/configs/webpack.config.renderer.dev.ts",
+    "start:renderer": "cross-env NODE_ENV=development DEBUG_PROJECT_PATH=D:/gsoc/Pluto.jl TS_NODE_TRANSPILE_ONLY=true webpack serve --config ./.erb/configs/webpack.config.renderer.dev.ts",
     "test": "jest"
   },
   "lint-staged": {
@@ -216,6 +216,7 @@
       "node_modules",
       "package.json"
     ],
+    "beforePack": ".erb/scripts/beforePack.js",
     "afterSign": ".erb/scripts/notarize.js",
     "mac": {
       "target": {

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "@teamsupercell/typings-for-css-modules-loader": "^2.5.1",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.2.0",
+    "@types/detect-port": "^1.3.2",
     "@types/jest": "^27.5.1",
     "@types/node": "17.0.33",
     "@types/react": "^18.0.9",
@@ -206,7 +207,7 @@
       }
     ],
     "nsis": {
-      "oneClick": false,
+      "oneClick": true,
       "perMachine": true,
       "runAfterFinish": false
     },
@@ -261,7 +262,8 @@
       "output": "release/build"
     },
     "extraResources": [
-      "./assets/**"
+      "./assets/**",
+      "./!assets/*.zip"
     ],
     "publish": {
       "provider": "github",

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pluto",
-  "version": "0.0.1-alpha",
+  "version": "0.0.2-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pluto",
-      "version": "0.0.1-alpha",
+      "version": "0.0.2-alpha",
       "hasInstallScript": true,
       "license": "MIT"
     }

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluto",
-  "version": "0.0.1-alpha",
+  "version": "0.0.2-alpha",
   "description": "Desktop application for running Pluto notebooks.",
   "license": "MIT",
   "author": {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -248,6 +248,7 @@ app.on('open-file', async (_event, file) => {
 app
   .whenReady()
   .then(() => {
+    log.verbose(chalk.grey('---------- BEGIN ----------'));
     createWindow();
     app.on('activate', () => {
       // On macOS it's common to re-create a window in the app when the

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -1,7 +1,9 @@
 import chalk from 'chalk';
 import Store from 'electron-store';
 
-const store = new Store<SettingsStore>();
+const store = new Store<SettingsStore>({
+  defaults: { 'JULIA-PATH': 'julia-1.7.3\\bin\\julia.exe' },
+});
 
 console.log(chalk.green('STORE:'), store.store);
 

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -8,7 +8,8 @@ declare global {
   type RunPlutoResponse = 'loading' | 'updating' | 'no_update' | PlutoURL;
 
   type SettingsStore = {
-    'JULIA-PATH'?: string;
+    'JULIA-PATH': string;
+    'CUSTOM-JULIA-PATH'?: string;
   };
 }
 


### PR DESCRIPTION
So this is a try-fix attempt to remove the need for admin permissions for the first run. 
* The need for first run was due to the need of extracting Julia portable zip, this PR removes the need for that by bundling the extracted folder instead of the zip.
* Size different is not much because electron-builder also compresses the assets. 
* Extracting functionality is still there, it acts as a backup.
* This PR also allows people to use custom Julia binaries by adding "CUSTOM-JULIA-PATH" key in the config file. If this is present, it takes priority over the default "JULIA-PATH".