### PR TITLE
Use the latest commit of Pluto.jl that includes the desktop UI changes

### DIFF
--- a/assets/env_for_julia/Manifest.toml
+++ b/assets/env_for_julia/Manifest.toml
@@ -239,7 +239,9 @@ version = "1.10.0"
 
 [[deps.Pluto]]
 deps = ["Base64", "Configurations", "Dates", "Downloads", "ExpressionExplorer", "FileWatching", "GracefulPkg", "HTTP", "HypertextLiteral", "InteractiveUtils", "LRUCache", "Logging", "LoggingExtras", "MIMEs", "Malt", "Markdown", "MsgPack", "Pkg", "PlutoDependencyExplorer", "PrecompileSignatures", "PrecompileTools", "REPL", "Random", "RegistryInstances", "RelocatableFolders", "SHA", "Scratch", "Sockets", "TOML", "Tables", "URIs", "UUIDs"]
-git-tree-sha1 = "91424262b8490c197b4d4451afd1ab9e412399fc"
+git-tree-sha1 = "c33f1a148fec220a7e764b51a2e30b2d21f94b6d"
+repo-rev = "f833f91b"
+repo-url = "https://github.com/fonsp/Pluto.jl.git"
 uuid = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 version = "0.20.21"
 


### PR DESCRIPTION
I followed the intstruction in CONTRIBUTING.md to do this:

```
cd assets/env_for_julia

julia --project

pkg>  add Pluto#f833f91b
```

Which is the commit hash where https://github.com/fonsp/Pluto.jl/pull/2651 was merged