### PR TITLE
[codex] Add Electron inspection workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ generated_assets/
 # Compiled TS output (not used by Forge, but the TS compiler may produce it)
 dist/
 /.claude/worktrees
+
+# Agent-browser screenshots and local browser automation state
+.agent-browser/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md
+
+Guidance for AI agents working in this repository.
+
+## Electron UI inspection
+
+This Electron Forge app can be launched with Chrome DevTools Protocol enabled so agents can inspect the rendered UI instead of coding blind.
+
+Use:
+
+```sh
+npm run start:inspect
+```
+
+This starts Electron with `--remote-debugging-port=9333` and sets `SKIP_GENERATE_ASSETS=1` so local inspection does not block on Julia asset provisioning. If you need the full asset hook, use:
+
+```sh
+npm run start:inspect:assets
+```
+
+Once the app is running, inspect it from another terminal:
+
+```sh
+npm run inspect:tabs
+npm run inspect:snapshot
+npm run inspect:snapshot:interactive
+npm run inspect:screenshot
+```
+
+Screenshots are written under `.agent-browser/`, which is ignored by git.
+
+## Agent-browser notes
+
+`agent-browser` is installed as a dev dependency. Prefer the npm scripts over global installs.
+
+For this app, `agent-browser tab` and `agent-browser connect 9333` may fail with `CDP error (Target.createTarget): Not supported`. The Electron CDP endpoint still works. Use `npm run inspect:tabs`, which reads `http://localhost:9333/json/list` through `scripts/listCdpTargets.mjs`.
+
+`agent-browser --cdp 9333 snapshot` and `agent-browser --cdp 9333 screenshot` work against the running Electron window.
+
+## Local-change hygiene
+
+Do not stage unrelated user changes. In particular, check `git status -sb` before committing and stage explicit files when the worktree is mixed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,29 @@ After the initial setup:
 - run `npm run start`
 > Node: Currently the code has some Windows-specific parts, such as checking for admin rights etc.
 
+## Inspect the Electron UI
+
+This project includes [agent-browser](https://agent-browser.dev/) so agents and contributors can inspect the running Electron renderer through Chrome DevTools Protocol.
+
+In one terminal, launch the app with CDP enabled:
+
+```sh
+npm run start:inspect
+```
+
+This skips the Julia asset-generation hook and assumes the normal development assets already exist. To run the full asset hook before launching, use `npm run start:inspect:assets`.
+
+Then, from another terminal:
+
+```sh
+npm run inspect:tabs
+npm run inspect:snapshot
+npm run inspect:snapshot:interactive
+npm run inspect:screenshot
+```
+
+The inspection port is `9333`. Screenshots are written to `.agent-browser/`, which is ignored by git.
+
 ## Working with Pluto.jl
 
 It is expected that those working on both Pluto.jl and PlutoDesktop will place them in the same parent directory. By default, PlutoDesktop will serve Pluto.jl assets from `../Pluto.jl/frontend` in development mode.
@@ -39,4 +62,3 @@ Modify the Julia version in the `bundler/scripts/beforePack.js` file. Git commit
 
 # Contributing
 See if there already exists and issue or an open PR against the issue you are trying to solve. If there isn't any, create a new issue.
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,8 @@
         "@typescript-eslint/eslint-plugin": "^8.62.0",
         "@typescript-eslint/parser": "^8.62.0",
         "@vercel/webpack-asset-relocator-loader": "^1.10.0",
+        "agent-browser": "^0.30.1",
+        "cross-env": "^10.1.0",
         "css-loader": "^7.1.4",
         "electron": "42.5.0",
         "eslint": "^9.39.4",
@@ -933,6 +935,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -3455,6 +3464,21 @@
         "node": ">= 14"
       }
     },
+    "node_modules/agent-browser": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/agent-browser/-/agent-browser-0.30.1.tgz",
+      "integrity": "sha512-VMIZH90PFe5vmazizovDYUAAGrUWZ+xCqyv9ceuDOuL283a8aRqsshIQ0PY02QcdCpi1b6dwYYZOvUhoCl08Xw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "agent-browser": "bin/agent-browser.js"
+      },
+      "engines": {
+        "node": ">=24.0.0",
+        "pnpm": ">=11.0.0"
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -4859,6 +4883,24 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,14 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "start:inspect": "cross-env SKIP_GENERATE_ASSETS=1 electron-forge start -- --remote-debugging-port=9333",
+    "start:inspect:assets": "electron-forge start -- --remote-debugging-port=9333",
+    "inspect:tabs": "node scripts/listCdpTargets.mjs 9333",
+    "inspect:targets": "node scripts/listCdpTargets.mjs 9333",
+    "inspect:snapshot": "agent-browser --cdp 9333 snapshot",
+    "inspect:snapshot:interactive": "agent-browser --cdp 9333 snapshot -i",
+    "inspect:screenshot": "agent-browser --cdp 9333 --screenshot-dir .agent-browser screenshot"
   },
   "keywords": [],
   "author": {
@@ -30,6 +37,8 @@
     "@typescript-eslint/eslint-plugin": "^8.62.0",
     "@typescript-eslint/parser": "^8.62.0",
     "@vercel/webpack-asset-relocator-loader": "^1.10.0",
+    "agent-browser": "^0.30.1",
+    "cross-env": "^10.1.0",
     "css-loader": "^7.1.4",
     "electron": "42.5.0",
     "eslint": "^9.39.4",

--- a/scripts/listCdpTargets.mjs
+++ b/scripts/listCdpTargets.mjs
@@ -1,0 +1,49 @@
+import http from 'node:http';
+
+const port = process.argv[2] ?? process.env.CDP_PORT ?? '9333';
+const url = `http://localhost:${port}/json/list`;
+
+const getJson = (targetUrl) =>
+  new Promise((resolve, reject) => {
+    const request = http.get(targetUrl, (response) => {
+      let body = '';
+
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => {
+        body += chunk;
+      });
+      response.on('end', () => {
+        if (response.statusCode < 200 || response.statusCode >= 300) {
+          reject(new Error(`CDP target request failed with HTTP ${response.statusCode}`));
+          return;
+        }
+
+        try {
+          resolve(JSON.parse(body));
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+
+    request.on('error', reject);
+  });
+
+try {
+  const targets = await getJson(url);
+
+  if (!Array.isArray(targets) || targets.length === 0) {
+    console.log(`No CDP targets found at ${url}`);
+    process.exit(0);
+  }
+
+  for (const [index, target] of targets.entries()) {
+    console.log(`${index}: [${target.type ?? 'unknown'}] ${target.title || '(untitled)'}`);
+    if (target.url) console.log(`   ${target.url}`);
+    if (target.webSocketDebuggerUrl) console.log(`   ${target.webSocketDebuggerUrl}`);
+  }
+} catch (error) {
+  console.error(`Unable to list CDP targets at ${url}`);
+  console.error(error?.message ?? error);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` with the Electron inspection workflow for AI agents.
- Add `agent-browser` and `cross-env` dev tooling plus npm scripts for CDP-based inspection.
- Add a small CDP target-list helper for this Electron runtime, where `agent-browser tab/connect` can fail with `Target.createTarget`.
- Document the workflow in `CONTRIBUTING.md` and ignore local `.agent-browser/` screenshots/state.

## Validation

- `npx eslint scripts/listCdpTargets.mjs`
- `npm run` shows the new `start:inspect` and `inspect:*` scripts
- Manually verified earlier that Electron launches with CDP on port 9333 and `agent-browser --cdp 9333 screenshot` captures the Pluto welcome page.

## Notes

- Full `npm run lint` currently fails on pre-existing lint coverage of `.claude/worktrees`, `generated_assets`, and existing source files.