### PR TITLE
[codex] Fix export menu refresh

### DIFF
--- a/src/menu.ts
+++ b/src/menu.ts
@@ -9,26 +9,30 @@ import { createPlutoWindow } from './index.ts';
 export default class MenuBuilder {
   private pluto: Pluto;
   private browser: BrowserWindow;
+  private contextMenuSetup: boolean;
   public hasbuilt: boolean;
 
   constructor(pluto: Pluto) {
     this.hasbuilt = false;
+    this.contextMenuSetup = false;
     this.pluto = pluto;
     this.browser = this.pluto.getBrowserWindow();
   }
 
   buildMenu = () => {
-    this.setupContextMenu(
-      process.env.NODE_ENV === 'development' ||
-        process.env.DEBUG_PROD === 'true',
-    );
+    if (!this.contextMenuSetup) {
+      this.setupContextMenu(
+        process.env.NODE_ENV === 'development' ||
+          process.env.DEBUG_PROD === 'true',
+      );
+      this.contextMenuSetup = true;
+    }
 
     // const menu = Menu.buildFromTemplate(this.buildDefaultTemplate());
     // this.pluto.getBrowserWindow().setMenu(menu);
 
     const menu = Menu.buildFromTemplate(this.buildDefaultTemplate());
     Menu.setApplicationMenu(menu); // Works on macOS + Windows
-
 
     this.hasbuilt = true;
   };

--- a/src/pluto.ts
+++ b/src/pluto.ts
@@ -75,18 +75,26 @@ class Pluto {
 
     const menuBuilder = new MenuBuilder(this);
 
-    let first = true;
-    this.win.on('page-title-updated', (_e, title) => {
-      generalLogger.verbose('Window', this.win.id, 'moved to page:', title);
-      if (this.win?.webContents.getTitle().includes('index.html')) return;
-      const pageUrl = new URL(this.win!.webContents.getURL());
-      const isPluto = pageUrl.href.includes('localhost:');
-      if (first || isPluto) {
-        first = false;
-        this.win?.setMenuBarVisibility(true);
+    let lastShowExport: boolean | undefined;
+    const refreshMenu = () => {
+      if (this.win.isDestroyed()) return;
+
+      const showExport = menuBuilder.showExport();
+      if (!menuBuilder.hasbuilt || showExport !== lastShowExport) {
+        lastShowExport = showExport;
+        this.win.setMenuBarVisibility(true);
         menuBuilder.buildMenu();
       }
+    };
+
+    this.win.on('page-title-updated', (_e, title) => {
+      generalLogger.verbose('Window', this.win.id, 'moved to page:', title);
+      refreshMenu();
     });
+    this.win.webContents.on('did-finish-load', refreshMenu);
+    this.win.webContents.on('did-navigate', refreshMenu);
+    this.win.webContents.on('did-navigate-in-page', refreshMenu);
+    this.win.on('focus', refreshMenu);
 
     // Open urls in the user's browser
     this.win.webContents.setWindowOpenHandler((edata) => {


### PR DESCRIPTION
## Summary

Fixes the Electron app menu so the Export menu appears when a notebook is opened after first visiting the Pluto welcome/main page in the same window.

## Root Cause

The app menu was rebuilt from `page-title-updated` using a `localhost:` URL heuristic. After the first menu build on the welcome page, navigating to the local `editor.html?...&id=...` notebook route could leave the menu in the non-exportable state because that URL did not satisfy the existing rebuild condition.

## Changes

- Refresh the menu on page load, navigation, in-page navigation, title updates, and focus.
- Rebuild only when the notebook export visibility state changes.
- Register the context menu listener once so repeated menu rebuilds do not stack duplicate handlers.

## Validation

- `npx tsc --noEmit`
- `git diff --check`

`npm run lint` was also attempted, but it still fails on existing repo-wide lint issues unrelated to this change.