### PR TITLE
[codex] Delay auto-update check until after launch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,21 +18,27 @@ import { getAssetPath } from './paths.ts';
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
 declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string;
 
+const AUTO_UPDATE_CHECK_DELAY_MS = 2 * 60 * 1000;
+
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (require('electron-squirrel-startup')) {
   app.quit();
-} else {
+}
+
+const scheduleAutoUpdateChecks = () => {
   // Check for new releases on GitHub (via update.electronjs.org), download them
   // in the background, and prompt the user to restart. No-op during development.
-  updateElectronApp({
-    updateSource: {
-      type: UpdateSourceType.ElectronPublicUpdateService,
-      repo: 'JuliaPluto/PlutoDesktop',
-    },
-    updateInterval: '1 hour',
-    logger: generalLogger,
-  });
-}
+  setTimeout(() => {
+    updateElectronApp({
+      updateSource: {
+        type: UpdateSourceType.ElectronPublicUpdateService,
+        repo: 'JuliaPluto/PlutoDesktop',
+      },
+      updateInterval: '1 hour',
+      logger: generalLogger,
+    });
+  }, AUTO_UPDATE_CHECK_DELAY_MS);
+};
 
 /**
  * Create a new BrowserWindow and attach a Pluto instance to it.
@@ -76,7 +82,7 @@ app.whenReady().then(async () => {
   // run (it copies the bundled Julia depot to a writable location).
   createPlutoWindow();
   await initGlobals();
-  startup(app, MAIN_WINDOW_WEBPACK_ENTRY);
+  startup(app, MAIN_WINDOW_WEBPACK_ENTRY, scheduleAutoUpdateChecks);
 
   // This is set here because it required the app to be ready
   session.defaultSession.on('will-download', (_event, item) => {

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -35,7 +35,11 @@ export async function initGlobals() {
   generalLogger.log(`Pluto will run on port: ${Globals.PLUTO_PORT}`);
 }
 
-export async function startup(app: App, loadingUrl: string) {
+export async function startup(
+  app: App,
+  loadingUrl: string,
+  onLaunched?: () => void,
+) {
   const SYSIMAGE_LOCATION = getAssetPath('pluto.so');
 
   const options = [`--project=${plutoProject}`];
@@ -82,6 +86,7 @@ export async function startup(app: App, loadingUrl: string) {
             });
 
             generalLogger.verbose('Entry url found:', Globals.PLUTO_URL);
+            onLaunched?.();
           }
         } else if (
           plutoLog.includes(


### PR DESCRIPTION
## Summary

Delays initialization of `update-electron-app` until PlutoDesktop has finished launching and Pluto has emitted its entry URL, then waits an additional two minutes before starting update checks.

## Why

The previous auto-update setup ran during main-process startup. Deferring it keeps update work out of the launch path and ensures the first check happens only after the app is actually ready for the user.

## Validation

- `npx tsc --noEmit`
- `npx eslint src\index.ts src\startup.ts`