### PR TITLE
Ship Pluto server as a sysimage instead of a bundled depot

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -35,8 +35,8 @@ The script ([scripts/setPlutoVersion.mjs](scripts/setPlutoVersion.mjs)) does fou
 
 1. Sets the package version to `<pluto-version>-buildNNN` via `npm version`, updating `package.json` and `package-lock.json`. Without an explicit build number, it starts at `1` and auto-increments when the current version is already based on the same Pluto version.
 2. Pins the exact Pluto version in [assets/env_for_julia/Project.toml](assets/env_for_julia/Project.toml) with a `Pluto = "=x.y.z"` compat entry.
-3. Updates [assets/env_for_julia/Manifest.toml](assets/env_for_julia/Manifest.toml) by running `Pkg.update("Pluto")`, so the build-time `Pkg.instantiate()` installs exactly the pinned version. It prefers the Julia binary in `generated_assets/` (the one the app ships) and falls back to `julia` on the PATH.
-4. Deletes `generated_assets/julia_depot` if present. The depot caches the previously installed Pluto, and asset generation skips preparation when it exists — a stale depot would silently ship the old Pluto.
+3. Updates [assets/env_for_julia/Manifest.toml](assets/env_for_julia/Manifest.toml) by running `Pkg.update("Pluto")`, so the build-time sysimage is compiled from exactly the pinned version. It prefers the Julia binary in `generated_assets/` (the one the app ships) and falls back to `julia` on the PATH.
+4. Deletes the sysimage build outputs (`generated_assets/pluto_sysimage.*`, `pluto_source/`, `pluto_server_depot/`) if present. Asset generation skips the (slow) sysimage build when these exist — stale outputs would silently ship the old Pluto.
 
 Requirements and gotchas:
 
@@ -46,7 +46,7 @@ Requirements and gotchas:
 
 ## Updating the bundled Julia version
 
-The Julia version is hardcoded in [scripts/generateAssets.js](scripts/generateAssets.js) (`JULIA_VERSION_PARTS`, near the top). It **must be ≥ 1.11**: the bundled depot ships precompile caches, and only Julia 1.11+ makes those caches relocatable (content hashes and `@depot`-relative source paths instead of absolute paths and mtimes). On 1.10 the caches embed build-machine paths and are rejected on every user's machine, forcing a multi-minute recompile on first launch.
+The Julia version is hardcoded in [scripts/generateAssets.js](scripts/generateAssets.js) (`JULIA_VERSION_PARTS`, near the top). It **must be ≥ 1.11**: notebook workers use the Julia install's own precompile caches (`<julia>/share/julia`), and only Julia 1.11+ makes those relocatable (content hashes and `@depot`-relative paths instead of absolute paths and mtimes). On 1.10 they embed build-machine paths and are rejected after every Squirrel relocation, forcing a multi-minute stdlib recompile.
 
 After changing the version:
 
@@ -56,23 +56,33 @@ After changing the version:
    julia --project=assets/env_for_julia -e "import Pkg; Pkg.resolve()"
    ```
 
-   `generateAssets.js` refuses to build if `Manifest.toml`'s `julia_version` doesn't match the bundled Julia, so this step is mandatory. Commit the updated Manifest.
+   `generateAssets.js` refuses to build if `Manifest.toml`'s `julia_version` doesn't match the bundled Julia, so this step is mandatory. Commit the updated Manifest. (The sysimage must be built with the exact Julia it will run under.)
 
-2. `generateAssets.js` detects a `generated_assets/julia-*` directory from a different version and removes it (along with the depot built against it) automatically on the next build. You only need to delete `generated_assets/` by hand if you want to force a clean rebuild.
+2. `generateAssets.js` detects a `generated_assets/julia-*` directory from a different version and removes it (along with the sysimage build outputs, which are Julia-version-specific) automatically on the next build. You only need to delete `generated_assets/` by hand if you want to force a clean rebuild.
 
-### How the bundled depot is used at runtime
+### How the sysimage is used at runtime
 
-The depot prepared at build time is **read-only** and only provides what's needed to launch the Pluto server. At runtime the server's `JULIA_DEPOT_PATH` is a stack (see `getServerDepotPath` in [src/plutoProcess.ts](src/plutoProcess.ts)):
+The Pluto server is launched with `julia --sysimage=<generated_assets/pluto_sysimage.*>` (see [src/startup.ts](src/startup.ts)). The sysimage has Pluto and all its dependencies compiled in, so the server needs **no package sources, no precompile caches, and no writes to any depot** — it starts fast and offline. Pluto's own frontend/runner/sample folders are embedded in the sysimage (via RelocatableFolders) and re-materialize into a scratchspace in the user's depot on first launch.
+
+The build (`buildPlutoSysimage` in [scripts/generateAssets.js](scripts/generateAssets.js)) produces three things in `generated_assets/`:
+
+- `pluto_sysimage.<dll|so|dylib>` — the server image.
+- `pluto_source/Pluto/` — Pluto's package source. Needed on disk so `PLUTO_LOCATION` (the `file://` frontend in [src/pluto.ts](src/pluto.ts)) and `Base.locate_package` resolve; the Pluto *module* itself comes from the sysimage.
+- `pluto_server_depot/artifacts/` — only the JLL binary artifacts the server resolves at runtime whose versions differ from the ones bundled with Julia (e.g. `MbedTLS_jll`).
+
+It also creates temporary `build_depot/`, `build_tools_depot/`, and `build_tools_env/` (PackageCompiler + its mingw toolchain live in the tools depot, isolated from the shipped artifacts) and deletes them when done.
+
+At runtime the server's `JULIA_DEPOT_PATH` is a stack (see `getServerDepotPath` in [src/plutoProcess.ts](src/plutoProcess.ts)):
 
 ```
-<user depot, usually ~/.julia> ; <bundled depot> ; <julia>/local/share/julia ; <julia>/share/julia
+<user depot, usually ~/.julia> ; <pluto_server_depot> ; <julia>/local/share/julia ; <julia>/share/julia
 ```
 
 - The user's depot comes first, so anything Pluto installs for notebooks — packages, registries, precompile caches — goes there, exactly as in a plain Julia session. Nothing accumulates in app-managed directories.
-- The bundled depot supplies Pluto and its dependencies, so a normal launch needs no network access and no recompilation.
-- The Julia-installation depots supply the standard-library caches; they must be listed explicitly because setting `JULIA_DEPOT_PATH` replaces Julia's default stack.
+- `pluto_server_depot` supplies the non-bundled JLL artifacts.
+- The Julia-installation depots supply the standard-library caches and Julia's own JLL artifacts; they must be listed explicitly because setting `JULIA_DEPOT_PATH` replaces Julia's default stack.
 
-Notebook (worker) processes inherit this same stack. They must — Pluto resolves notebook environments in the server process, and a package it reuses from the bundled depot has to remain loadable in the worker. `Pkg` never reinstalls into the read-only bundled depot; new packages land in the user depot.
+Notebook (worker) processes inherit this stack but launch with the **default** Julia sysimage — Malt starts them with just the Julia executable path, and Pluto passes no `--sysimage` flag. `PlutoRunner` (stdlib-only deps) precompiles into the user's depot on first notebook launch. So userland runs on plain Julia with the normal global depot, unaffected by the server's sysimage.
 
 ## Making a release
 

--- a/SYSIMAGE_INVESTIGATION.md
+++ b/SYSIMAGE_INVESTIGATION.md
@@ -1,0 +1,394 @@
+# Sysimage approach — investigation log
+
+Branch: `sysimage-approach` (based off `julia-1.12-depot-stacking`).
+
+## Goal (restated)
+
+1. The app must always work **without internet**.
+2. If the app ships its own Julia depot, that depot must **not keep growing on
+   every update**; ideally **no writes except logs**.
+3. **Userland (notebook) code must use the normal global Julia depot** and the
+   **default Julia sysimage**. Anything the app ships is only for launching the
+   Pluto *server*.
+
+## New approach being investigated
+
+Instead of shipping a big **depot** (package sources + ~68 MB of precompile
+caches that invalidate on relocation), ship Pluto compiled into a **sysimage**
+and launch the Pluto server with `--sysimage`. Pluto is designed to run from a
+sysimage. Notebook worker processes must keep using the *default* sysimage.
+
+Reference: an old commit that had (commented-out) PackageCompiler sysimage
+generation — https://github.com/JuliaPluto/PlutoDesktop/tree/0527a557a7fba7fca2e5ed0ce04e9760788ee634
+
+## Key questions
+
+- **Q1.** Can we build a Pluto sysimage with the bundled Julia (1.12.6)?
+- **Q2.** Can we launch the Pluto server from that sysimage **without** the
+  Pluto packages living in a depot (i.e. no `compiled/` caches, minimal/no
+  `packages/`)? What is the *minimum* on-disk footprint required?
+- **Q3.** Do notebook worker processes (userland) use the **default** sysimage,
+  not the Pluto one? And do they use the user's normal depot?
+
+---
+
+## Findings so far (static code reading)
+
+### The frontend forces Pluto *source* to exist on disk (independent of sysimage)
+
+`src/pluto.ts` `resolveHtmlPath` (line ~562) loads the editor UI as a **local
+file**:
+
+```
+file:///${PLUTO_LOCATION}/frontend/editor.html?...&pluto_server_url=http://localhost:PORT...
+```
+
+`PLUTO_LOCATION` comes from `findPluto()` → `assets/locate_pluto.jl` →
+`Base.locate_package(Base.identify_package("Pluto"))`, which resolves the Pluto
+package's source path **from the active project's manifest**. So regardless of
+the sysimage, we must ship Pluto's `frontend/` (realistically the whole Pluto
+package source) on disk, and the env manifest must point at it.
+
+Implication: the sysimage removes the need for the **`compiled/` caches** (68 MB,
+the part that invalidates), and possibly avoids needing package *sources* for
+Pluto's dependencies — but **Pluto's own source dir must ship** for the frontend.
+
+### Q3 (userland → default sysimage) looks already-solved by Malt
+
+`Pluto.jl/src/evaluation/WorkspaceManager.jl` launches workers via
+`Malt.Worker(; exeflags=_convert_to_flags(compiler_options))`.
+
+- `Configuration.jl`: `SYSIMAGE_DEFAULT = nothing`, and `_convert_to_flags` only
+  emits `--sysimage=...` when the field is non-`nothing`. So **no** `--sysimage`
+  flag is passed to workers by default.
+- `Malt.jl` (`Malt/OteGQ/src/Malt.jl`): `Worker(; exename=Base.julia_cmd()[1], ...)`
+  and `_get_worker_cmd` builds `` `$exename --startup-file=no $exeflags worker.jl` ``.
+  It uses **only the executable path** (`julia_cmd()[1]`), *not* the parent's
+  full `julia_cmd()` which would carry `-J<current sysimage>`.
+
+⇒ Workers launch with the **default** sysimage as long as PlutoDesktop does
+**not** set `compiler_options.sysimage`. To be verified empirically (Q3 test).
+
+Caveat: workers inherit the parent process **environment**, so whatever
+`JULIA_DEPOT_PATH` the server runs with is inherited by workers. For goal (3)
+that stack's first entry must be the user's normal depot.
+
+### Size tradeoff (measured)
+
+- Current bundled depot: **119 MB** total = `compiled/` **68 MB** + `packages/` **36 MB** + rest.
+- Default `sys.dll` (bundled Julia 1.12.6): **303 MB**.
+- An **incremental** Pluto sysimage builds on top of the base ⇒ expect ~**350–450 MB**.
+
+So on raw disk the sysimage is *larger* than the depot, and each Squirrel update
+ships a new copy. The win is **robustness**: no precompile caches to invalidate,
+**zero writes / zero recompilation** for the server, guaranteed offline. (To be
+measured once built.)
+
+---
+
+### What the Pluto *server* reads from `pkgdir(Pluto)` at runtime
+
+`Pluto.jl/src/Pluto.jl`: `project_relative_path(root, xs...)` →
+`normpath(joinpath(pkgdir(Pluto), root, xs...))` (frontend uses a
+RelocatableFolders `@path`, everything else uses `pkgdir`).
+
+Server-side consumers that must resolve on disk:
+- **`src/runner/Loader.jl`** and **`src/runner/PlutoRunner/Project.toml`**
+  (`WorkspaceManager.process_preamble`, lines 37-39) — read every time a
+  notebook worker is spawned. If `pkgdir(Pluto)` is wrong, **no notebook can
+  start.** ← the critical one.
+- `sample/*.jl` (sample notebooks), `frontend-dist/*` (HTML export inlining).
+
+⇒ **`pkgdir(Pluto)` must resolve to the shipped on-disk Pluto source** even
+though the module itself comes from the sysimage. This is the central Q2 test.
+
+### Consolidated requirements for the sysimage design
+
+Must ship on disk (read-only):
+1. `pluto_sysimage.dll` — Pluto + all deps compiled in (no `compiled/` caches).
+2. **Pluto's own package source** (`frontend/`, `src/runner/`, `sample/`, …) at
+   a fixed path, with an env whose **manifest points Pluto at that path**, so
+   `Base.locate_package` (→ `PLUTO_LOCATION`, frontend file://) and
+   `pkgdir(Pluto)` (→ worker bootstrap) both resolve.
+
+Possibly NOT needed (the hoped-for win — to be tested in E2):
+- Pluto's **dependencies' sources** on disk (they're in the sysimage).
+- Any `compiled/` precompile caches (all compiled code is in the sysimage).
+- A writable depot for the server at all.
+
+Userland (worker) side, unchanged from a normal Julia:
+- Workers load `PlutoRunner` from the on-disk Pluto source into the **user
+  depot** using the **default sysimage** — exactly the "userland uses the global
+  depot" behavior we want.
+
+## Experiment log
+
+(times are approximate; running with bundled Julia 1.12.6)
+
+### E1 — Build a Pluto sysimage
+
+Build env (isolated): `Pluto = "=1.0.1"` + `PackageCompiler v2.4.0`, built with
+bundled Julia **1.12.6**, isolated depot stacked over the Julia share depots.
+`create_sysimage(["Pluto"]; incremental=true, project=env)`.
+
+- Instantiate + precompile of the build env: **~1 min** (Pluto 1.0.1 + 42 deps).
+  Pluto's `PrecompileTools.@compile_workload` runs during this.
+- **First attempt FAILED at the link step**, not at Julia level: PackageCompiler
+  on Windows downloads a **mingw-w64** GCC artifact to link the sysimage, and
+  extracting it blew past Windows **MAX_PATH (260)** because the build depot was
+  under the very long agent scratchpad dir:
+  `…\scratchpad\sysimage_build\depot\artifacts\jl_XXXX\extracted_files\mingw64\lib\gcc\x86_64-w64-mingw32\14.2.0\finclude\ieee_arithmetic.mod`.
+  → `SystemError: opening file … No such file or directory` on both artifact
+  mirrors (the identical error on both = extraction, not network).
+- **Fix:** relocate the build depot to a short root (`C:\Users\20245075\jsib`).
+  **Lesson for CI/build:** the sysimage build needs a C toolchain (mingw-w64 on
+  Windows) — an extra build-time dependency and an offline-build consideration —
+  and the build depot/artifact path must stay short on Windows.
+
+Rebuild with the short path: **SUCCESS**.
+
+- Output: `pluto_sysimage.dll` = **411 MB** (default `sys.dll` is 303 MB, so Pluto
+  adds ~108 MB of compiled code + embedded folders — see RelocatableFolders below).
+- Total build wall-clock (instantiate + precompile + link): a few minutes.
+
+**⇒ Q1 answered: YES.** We can build a Pluto sysimage with the bundled Julia
+1.12.6. Only real gotcha is the mingw-w64 toolchain + Windows path length.
+
+### E2 — Launch Pluto from the sysimage with (almost) no depot
+
+Setup: env dev's Pluto at a **shipped source path** (`…/jsib/shipped/Pluto`,
+distinct from the build depot's copy). Depot stack = *empty* user depot +
+"shipped depot" + Julia's own share depots. **No `packages/`, no `compiled/`.**
+
+First attempt hit a **new requirement**: JLL packages baked into the sysimage
+resolve their **binary artifacts at runtime** in `__init__`
+(`@artifact_str` → `<depot>/artifacts/<hash>`). `MbedTLS_jll` fatally aborted
+startup because its artifact wasn't on disk. Notes:
+- The build env resolved `MbedTLS_jll` to a **newer registry version** than the
+  one Julia 1.12.6 bundles, so its artifact isn't in the Julia install. Other
+  JLLs (OpenSSL, Zlib, …) are still stdlib JLLs and resolved from Julia's share
+  depot.
+- Fix: ship an **`artifacts/` dir** with the needed JLL binaries. Only ~6 MB
+  here (the current depot design already ships ~16 MB of these).
+
+With a tiny artifacts-only shipped depot added, **the probe succeeded**:
+`import Pluto` from the sysimage in **0.002 s**, `locate_package(Pluto)` returns
+the shipped source (feeds `PLUTO_LOCATION`).
+
+But this "passed" partly because the build path still existed on this machine.
+The **true relocation test** (renamed the build Pluto dir away, so no build path
+exists) is the important one — and it **also passed**:
+
+```
+BUILD_SRC exists on disk? false        (true relocation)
+import Pluto OK in 0.002 s (from sysimage)
+locate_package -> shipped src ✓  (PLUTO_LOCATION works)
+src/runner Loader   isfile=true  scratch=true   …/testdepot/scratchspaces/…/Loader.jl
+PlutoRunner.toml    isfile=true  scratch=true   …/scratchspaces/…/PlutoRunner/Project.toml
+frontend/editor     isfile=true  scratch=true   …/scratchspaces/…/editor.html
+frontend-dist       isfile=true  scratch=true   …/scratchspaces/…/editor.html
+sample notebook     isfile=true  scratch=true   …/scratchspaces/…/Basic.jl
+```
+
+**Why it works — RelocatableFolders embeds the folders in the sysimage.**
+Pluto's `project_relative_path` special-cases the critical dirs to
+`RelocatableFolders.@path` consts (`RUNNER_DIR`, `FRONTEND_DIR`,
+`FRONTEND_DIST_DIR`, `SAMPLE_DIR`); only *other* roots use `pkgdir(Pluto)`.
+`@path` reads **every file into a `Dict{String,Vector{UInt8}}` inside the struct**
+at build time, so those folders are **baked into the 411 MB sysimage as blobs**.
+At runtime, if the original (build) path is gone, `getpath` **writes the blobs
+into a scratchspace** in the first depot and serves from there.
+
+- The only production `project_relative_path` call that uses the `pkgdir`
+  fallback is the non-production `test` root. So the fact that `pkgdir(Pluto)`
+  stays "baked" to the build path (Julia skips `set_pkgorigin_version_path` for
+  sysimage-resident modules — verified in `loading.jl`) **does not matter** in
+  practice.
+
+**⇒ Q2 answered: YES.** The Pluto server launches from the sysimage with **no
+package sources and no precompile caches in any depot** — only a tiny
+`artifacts/` dir. Pluto's own frontend/runner/sample ship *inside* the sysimage.
+
+### E3 — Notebook workers use the DEFAULT sysimage
+
+Started a real Pluto worker the way the server does
+(`WorkspaceManager.get_workspace`) from the sysimage server:
+
+```
+SERVER SYSIMAGE : …/jsib/pluto_sysimage.dll
+WORKER SYSIMAGE : …/julia-1.12.6/lib/julia/sys.dll     ← DEFAULT, not Pluto's
+WORKER PROJECT  : …/userdepot/environments/v1.12/Project.toml   ← user global env
+WORKER DEPOTS   : userdepot (writable) first
+WORKER julia_cmd: julia.exe -C native -J…/lib/julia/sys.dll -g1 --startup-file=no
+```
+
+PlutoRunner precompiled into the **user depot** in ~6 s from **stdlib-only**
+deps (per its Project.toml). No `--sysimage` flag is passed to the worker.
+
+**⇒ Q3 answered: YES, automatically.** Userland runs on the default sysimage and
+the user's normal global depot. Nothing special is required as long as
+PlutoDesktop does **not** set `compiler_options.sysimage`.
+
+### E4 — End-to-end server launch (real `run_pluto.jl`)
+
+Launched the actual `assets/run_pluto.jl` under the sysimage. One test-env fix
+was needed: `run_pluto.jl` does `copy!(LOAD_PATH, ["@"])`, so the active project
+must directly declare every stdlib it imports (`Logging`, `Pkg`) plus `Pluto` —
+exactly what the production `env_for_julia/Project.toml` already does.
+
+Result: **server ready (HTTP 200 on `/` and `/edit`) in ~3.7 s** (vs the ~15 s
+the current depot design reportedly takes). `/edit` is served from the
+scratchspace-materialized frontend.
+
+---
+
+## Answers
+
+| Question | Answer |
+|---|---|
+| Q1 build a Pluto sysimage with bundled Julia 1.12.6 | **Yes** (411 MB, needs mingw-w64 + short build path on Windows) |
+| Q2 launch server from sysimage without Pluto packages in a depot | **Yes** — only a ~6–16 MB `artifacts/` dir; frontend/runner/sample are embedded in the sysimage |
+| Q3 userland/workers use the default sysimage & global depot | **Yes, automatically** (Malt uses `julia_cmd()[1]`; `SYSIMAGE_DEFAULT = nothing`) |
+
+Bonus: server startup ~3.7 s (down from ~15 s), and **zero recompilation / zero
+writes to any app-managed directory** for the server.
+
+## Recommended architecture
+
+Ship (all read-only):
+1. Julia 1.12.6 install (already shipped) — provides the **default** sysimage for
+   workers and its stdlib/JLL artifacts.
+2. `pluto_sysimage.dll` (~411 MB) in `generated_assets/` — the Pluto server image.
+3. A tiny **`artifacts/`-only depot** (~6–16 MB) for JLLs whose versions drift
+   from Julia's bundled ones (MbedTLS_jll, …). *Or* pin those JLLs to Julia's
+   bundled versions and ship nothing.
+4. **Pluto source** (~15–25 MB: `frontend/`, `frontend-dist/`, `src/`, `sample/`,
+   `Project.toml`) — needed so `locate_package` → `PLUTO_LOCATION` resolves for
+   PlutoDesktop's `file://` frontend. (Alternatively: hardcode this path, since
+   we control where we ship it, and drop `locate_pluto.jl`.)
+5. `env_for_julia` with `Project.toml` (`Logging`, `Pkg`, `Pluto`) + a `Manifest`
+   pointing Pluto at the shipped source via a **relative** path (relocatable).
+
+Server launch: `julia --sysimage=<pluto_sysimage> --project=<env_for_julia> run_pluto.jl …`
+with `JULIA_DEPOT_PATH = <user ~/.julia> ; <artifacts depot> ; <julia share depots>`.
+
+Drop from the current design: the **~68 MB `compiled/` caches** (in the sysimage
+now) and the **~36 MB `packages/` sources** for Pluto's deps (in the sysimage).
+
+### Net effect vs current depot-stacking design
+
+- **Robustness (the point):** server needs **no precompilation ever** and makes
+  **no writes** to any app dir → no cache invalidation, guaranteed offline start.
+- **Disk:** bigger — a 411 MB image replaces a 119 MB depot, and Squirrel keeps
+  per-version copies. Trades disk for immutability/robustness.
+- **Speed:** ~3.7 s server start vs ~15 s.
+
+## Implementation decisions (confirmed by follow-up tests)
+
+- **Keep `env_for_julia` and `set-pluto-version` unchanged.** A follow-up test
+  launched the server from the sysimage using the *existing checked-in*
+  `assets/env_for_julia` (registry Manifest with `git-tree-sha1`, no packages on
+  disk) + an artifacts-only depot → **HTTP 200 in 4.6 s**. `import Pluto` uses
+  the sysimage-resident module (matched by UUID); the Manifest is only consulted
+  to resolve the UUID + the stdlib set, so its recorded tree-hash/path never has
+  to exist on disk. This means the Manifest strategy needs **no changes** and
+  `PLUTO_LOCATION` can simply be hardcoded to the shipped `pluto_source/Pluto`.
+- **`cpu_target` is a non-issue.** `PackageCompiler.create_sysimage` already
+  defaults `cpu_target = default_app_cpu_target()`, a portable multi-arch target
+  (x86_64: `generic;sandybridge,…;haswell,…`). My existing image was already
+  built portably. So we pass no `cpu_target`.
+
+### Implemented layout (branch `sysimage-approach`)
+
+`generated_assets/` ships: `julia-<ver>/` (unchanged, default sysimage for
+workers) + `pluto_sysimage.<dll|so|dylib>` + `pluto_source/Pluto/` (frontend/
+src/sample for `PLUTO_LOCATION`) + `pluto_server_depot/artifacts/` (JLL
+binaries). No `packages/`, no `compiled/`. Build-time temp depots
+(`build_depot`, `build_tools_depot`, `build_tools_env`) are created and deleted
+by `generateAssets.js`; PackageCompiler + its mingw toolchain live in the
+tools depot so they never reach the shipped artifacts.
+
+## Implementation (branch `sysimage-approach`)
+
+Files changed:
+
+- **`scripts/generateAssets.js`** — replaced the old `prepareJuliaDepot` /
+  disabled `precompilePluto` with `buildPlutoSysimage`: instantiate
+  `env_for_julia` into a temp `build_depot`; install PackageCompiler into a
+  separate temp `build_tools_depot` (so its mingw toolchain never reaches the
+  shipped artifacts); `create_sysimage(["Pluto"])` → `pluto_sysimage.*`; extract
+  Pluto source → `pluto_source/Pluto/` (minus `test/`, `frontend-bundler/`) and
+  JLL artifacts → `pluto_server_depot/artifacts/`; delete temp depots. Added a
+  `runJulia` helper and `fixupMacPermissions`. Stale-version cleanup now removes
+  the sysimage outputs (and any legacy `julia_depot`).
+- **`src/paths.ts`** — replaced `BUNDLED_DEPOT_LOCATION` with
+  `PLUTO_SYSIMAGE_LOCATION` (per-platform basename), `PLUTO_SERVER_DEPOT_LOCATION`,
+  and `PLUTO_SOURCE_LOCATION`.
+- **`src/plutoProcess.ts`** — `getServerDepotPath` now stacks the artifacts-only
+  `pluto_server_depot` instead of the full depot; `findPluto` returns the shipped
+  `pluto_source/Pluto` directly (no Julia subprocess), keeping `locate_pluto.jl`
+  only as a dev/no-sysimage fallback.
+- **`src/startup.ts`** — the `--sysimage` flag now points at
+  `PLUTO_SYSIMAGE_LOCATION` (was a hardcoded `assets/pluto.so`); warns if absent.
+- **`assets/run_pluto.jl`** — comments updated for the sysimage design; the
+  `Pkg.instantiate()` branch is now just a dev/no-sysimage repair path.
+- **`scripts/setPlutoVersion.mjs`** — deletes the sysimage build outputs (not
+  `julia_depot`) so the next build rebuilds from the new Pluto.
+- **`MAINTENANCE.md`** — rewrote the runtime/depot section for the sysimage.
+
+`env_for_julia` (Project.toml + Manifest) and `set-pluto-version`'s version
+plumbing are **unchanged** (see the decision above).
+
+### Validation of the implemented build (real artifacts)
+
+Ran the actual `generateAssets` hook (via a driver) on this machine:
+
+- Outputs in `generated_assets/`: `pluto_sysimage.dll` **410 MB**,
+  `pluto_source/Pluto/` **25 MB** (frontend/editor.html present), and
+  `pluto_server_depot/artifacts/` **16 MB**. Temp `build_depot` /
+  `build_tools_depot` / `build_tools_env` were created and **cleaned up**.
+- mingw-w64 downloaded and extracted fine at the real repo path (no MAX_PATH).
+- Launching the shipped sysimage + `env_for_julia` via `run_pluto.jl` with a
+  **fresh empty user depot** + the production depot stack → **HTTP 200 on `/`
+  and `/edit` in ~5 s**.
+- Worker test against the shipped artifacts: **server on `pluto_sysimage.dll`,
+  worker on the default `sys.dll`**, worker's global env in the user depot.
+- **Full Electron app** (`npm run start:inspect`): logs show
+  `Pluto found at: …\generated_assets\pluto_source\Pluto`,
+  `System image found at …\pluto_sysimage.dll. Julia will use this instead of
+  the default`, and `Entry url found` — server up, frontend loading, no errors.
+  (In dev, `resolveHtmlPath` still serves the frontend from the local `Pluto.jl`
+  checkout; packaged builds use the shipped `pluto_source`.)
+
+## Open considerations / follow-ups
+
+1. **cpu_target** — resolved: PackageCompiler's default is already portable.
+2. **Worker first-run registry**: the worker's PlutoRunner boot environment
+   caused Pkg to install the General registry. On a *truly offline, fresh* user
+   machine this could fail. This is **shared with the current design** (which
+   strips registries) and independent of the sysimage decision — but goal (1)
+   demands a dedicated offline test and, if needed, shipping a registry or a
+   pre-built boot environment for workers.
+3. **First-launch scratchspace write**: ~15 MB of Pluto frontend/runner is
+   written once into the user depot's `scratchspaces/` on first server start
+   (RelocatableFolders materialization). One-time, in the user depot (not an app
+   dir) — acceptable, but note it isn't literally "zero writes".
+4. **Build-time C toolchain**: sysimage builds need mingw-w64 (Windows). On a
+   normal repo checkout the build depot path is short enough to dodge MAX_PATH
+   (verified: `generated_assets/build_tools_depot/…` builds fine); the pathology
+   only appeared under the very long agent scratchpad. CI (GitHub windows-latest)
+   has mingw fetched as an artifact and a short workspace path, so no extra setup.
+5. **`src/startup.ts` sysimage detection** — done (points at
+   `PLUTO_SYSIMAGE_LOCATION`).
+6. **`generateAssets.js` build step** — done (`buildPlutoSysimage`).
+7. **Installer size**: the ~411 MB sysimage makes `PlutoSetup.exe` and each
+   `-full.nupkg` much larger; each Squirrel update ships a full copy. Worth
+   confirming this is acceptable before release (it's the main cost of the
+   approach). No delta updates with Squirrel.Windows.
+
+## Reproduction
+
+All fixtures live under `C:\Users\20245075\jsib` (short path to dodge MAX_PATH):
+`env/` + `build.jl` (build), `probe.jl` + `run_e2.sh` (E2), `e3.jl` + `run_e3.sh`
+(E3), `shipped/Pluto` (shipped source), `shipped_depot/artifacts` (JLL artifacts),
+`testenv/` (env with relative-ish dev of Pluto).

--- a/assets/run_pluto.jl
+++ b/assets/run_pluto.jl
@@ -14,11 +14,22 @@ copy!(LOAD_PATH, ["@"])
 import Logging
 Logging.global_logger(Logging.ConsoleLogger(stdout));
 
-# This process runs with a JULIA_DEPOT_PATH that stacks the app's bundled read-only depot (and the depots inside the Julia installation) behind the user's own depot (see getServerDepotPath in plutoProcess.ts). The bundled depot contains the sources and precompile caches for everything in our manifest, so a normal launch needs no Pkg operations and works offline.
+# This process is normally launched with `--sysimage=<pluto_sysimage>` (see
+# startup.ts), which has Pluto and all its dependencies precompiled in. So
+# `import Pluto` resolves to the sysimage-resident module instantly, needs no
+# package sources or precompile caches in any depot, and works offline. The
+# JULIA_DEPOT_PATH still stacks a small read-only depot (JLL artifacts) and the
+# Julia install's own depots behind the user's depot (see getServerDepotPath in
+# plutoProcess.ts).
 #
-# Notebook processes inherit the same stack. The user's depot comes first, so everything Pluto installs for notebooks (packages, registries, precompile caches) goes to the user's normal depot, like in a plain Julia session. The stack must be shared with notebook processes because notebook environments are resolved in *this* process: a version that resolution finds in the bundled depot would not be downloaded again, so notebook processes need to see the bundled depot too.
+# Notebook (worker) processes inherit this stack but launch with the DEFAULT
+# Julia sysimage, and install everything they need into the user's depot, which
+# comes first — exactly like a plain Julia session.
 #
-# Pkg.instantiate() is only a repair path: it downloads the registry and any missing packages into the user's depot, so only run it when loading actually fails.
+# The Pkg.instantiate() branch is only a repair path for the dev/no-sysimage
+# case: when there is no sysimage and Pluto isn't installed in the user's depot,
+# it downloads the registry and missing packages. With the sysimage, `import
+# Pluto` never fails, so this branch is not taken.
 try
     import Pluto
 catch e

--- a/scripts/generateAssets.js
+++ b/scripts/generateAssets.js
@@ -8,7 +8,6 @@ import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import unzip from 'extract-zip';
 import { execSync } from 'child_process';
-import { exit } from 'process';
 
 
 
@@ -60,7 +59,36 @@ if (platform === 'win32') {
   throw new Error(`Unsupported platform: ${platform}`);
 }
 
-const DEPOT_NAME = `julia_depot`;
+// Sysimage approach (see SYSIMAGE_INVESTIGATION.md): instead of shipping a full
+// Julia depot (package sources + relocation-fragile precompile caches), we ship
+// Pluto compiled into a sysimage. What ends up in generated_assets/:
+//   - pluto_sysimage.<dll|so|dylib> : Pluto + all deps compiled in. Launched
+//     with `julia --sysimage=...`; the Pluto server needs no precompilation and
+//     works offline. Notebook workers keep using the DEFAULT sysimage.
+//   - pluto_source/Pluto/           : Pluto's own package source. Needed on disk
+//     so PLUTO_LOCATION (the file:// frontend) resolves; also the source the
+//     RelocatableFolders-embedded frontend/runner correspond to.
+//   - pluto_server_depot/artifacts/ : the JLL binary artifacts Pluto's deps
+//     resolve at runtime (e.g. MbedTLS_jll) whose versions differ from the ones
+//     bundled with Julia. Everything else is in the sysimage.
+const SYSIMAGE_BASENAME =
+  platform === 'win32'
+    ? 'pluto_sysimage.dll'
+    : platform === 'darwin'
+      ? 'pluto_sysimage.dylib'
+      : 'pluto_sysimage.so';
+const SYSIMAGE_LOCATION = path.join(generatedAssetsDir, SYSIMAGE_BASENAME);
+const PLUTO_SOURCE_LOCATION = path.join(generatedAssetsDir, 'pluto_source');
+const SERVER_DEPOT_LOCATION = path.join(generatedAssetsDir, 'pluto_server_depot');
+// Temporary build-only directories, removed after the sysimage is built. Keeping
+// PackageCompiler (and the ~700 MB mingw-w64 toolchain it downloads on Windows)
+// in a separate depot from the Pluto env means the shipped artifacts stay clean.
+const BUILD_DEPOT_LOCATION = path.join(generatedAssetsDir, 'build_depot');
+const BUILD_TOOLS_DEPOT_LOCATION = path.join(generatedAssetsDir, 'build_tools_depot');
+const BUILD_TOOLS_ENV_LOCATION = path.join(generatedAssetsDir, 'build_tools_env');
+
+// PackageCompiler.jl — pinned loosely; only used at build time.
+const PACKAGE_COMPILER_UUID = '9b87118b-4619-50d2-8e1e-99f35a4d4d9d';
 
 // The app version is `<pluto-version>-buildNNN` (see MAINTENANCE.md), and the
 // Julia environment must pin exactly that Pluto version. All three files are
@@ -128,189 +156,184 @@ const downloadJulia = async () => {
   console.log(`\tDownloaded Julia ${JULIA_VERSION} for ${platform}`);
 };
 
-// Currently disabled, see https://github.com/JuliaPluto/PlutoDesktop/issues/56
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const precompilePluto = async ({ julia_path }) => {
-  // TODO: You need to add PackageCompiler to some environment for this to work.
-
-  const SYSIMAGE_LOCATION = path.join(
-    generatedAssetsDir,
-    // TODO: auto version number
-    'pluto.so',
-  );
-
-  // immediately return if the sysimage has already been compiled
-  if (fs.existsSync(SYSIMAGE_LOCATION)) {
-    return new Promise((resolve) => resolve());
-  }
-
-  const PRECOMPILE_SCRIPT_LOCATION = path.join(generatedAssetsDir, 'precompile.jl');
-  const PRECOMPILE_EXECUTION_LOCATION = path.join(
-    generatedAssetsDir,
-    'precompile_execution.jl',
-  );
-
-  const res = spawn(julia_path, [
-    `--project=${path.join(generatedAssetsDir, 'env_for_julia')}`,
-    PRECOMPILE_SCRIPT_LOCATION,
-    SYSIMAGE_LOCATION,
-    PRECOMPILE_EXECUTION_LOCATION,
-  ]);
-
-  // stderr includes precompile status text
-  res.stderr.on('data', (data) => {
-    process.stdout.write(data?.toString?.());
-  });
-
-  return new Promise((resolve) => {
-    res.once('close', (exit_code) => {
-      if (exit_code === 0) {
-        console.info('Pluto has been precompiled to', SYSIMAGE_LOCATION);
-      } else {
-        console.error('Pluto precompile failed');
-        exit(exit_code);
-      }
-      resolve(SYSIMAGE_LOCATION);
+// Run a Julia process, streaming its output, and resolve/reject on exit code.
+const runJulia = (julia_path, args, env) =>
+  new Promise((resolve, reject) => {
+    const res = spawn(julia_path, args, {
+      env: { ...process.env, ...env },
+    });
+    res.stdout.on('data', (data) => process.stdout.write(data?.toString?.()));
+    res.stderr.on('data', (data) => process.stderr.write(data?.toString?.()));
+    res.on('error', reject);
+    res.once('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`Julia exited with code ${code}: ${args.join(' ')}`));
     });
   });
+
+// Recreate the extended-attribute / permission fixup the old depot preparation
+// did, so shipped files don't break macOS code signing. No-op off macOS.
+const fixupMacPermissions = (dir) => {
+  if (platform !== 'darwin' || !fs.existsSync(dir)) return;
+  // (🤖🤖 This block is AI written and not tested on macOS.)
+  try {
+    execSync(`find "${dir}" -type f -exec chmod u+w {} +`, { stdio: 'ignore' });
+    execSync(`find "${dir}" -type d -exec chmod u+w {} +`, { stdio: 'ignore' });
+    execSync(`xattr -rc "${dir}" 2>/dev/null || true`, { stdio: 'ignore' });
+    execSync(`find "${dir}" -type f -exec chmod 644 {} +`, { stdio: 'ignore' });
+    execSync(`find "${dir}" -type d -exec chmod 755 {} +`, { stdio: 'ignore' });
+  } catch (error) {
+    console.warn('Warning: Could not fix file permissions:', error.message);
+  }
 };
 
-const prepareJuliaDepot = async ({ julia_path }) => {
-  console.log('prepareJuliaDepot: Starting...');
-  console.log('prepareJuliaDepot: Julia path:', julia_path);
-  
+// Build the Pluto sysimage and extract the small on-disk pieces the app still
+// needs (Pluto source for PLUTO_LOCATION, and the JLL artifacts). See the block
+// comment near SYSIMAGE_LOCATION and SYSIMAGE_INVESTIGATION.md.
+const buildPlutoSysimage = async ({ julia_path }) => {
   if (!fs.existsSync(julia_path)) {
     throw new Error(`Julia executable not found at: ${julia_path}`);
   }
 
-  const DEPOT_LOCATION = path.join(generatedAssetsDir, DEPOT_NAME);
-  console.log('prepareJuliaDepot: DEPOT_LOCATION:', DEPOT_LOCATION);
-  
-  
-  // immediately return if the depot has already been prepared
-  if (fs.existsSync(DEPOT_LOCATION)) {
-    console.info('DEPOT preparation already done', DEPOT_LOCATION);
+  const plutoSrcDir = path.join(PLUTO_SOURCE_LOCATION, 'Pluto');
+  const artifactsDir = path.join(SERVER_DEPOT_LOCATION, 'artifacts');
+  if (
+    fs.existsSync(SYSIMAGE_LOCATION) &&
+    fs.existsSync(plutoSrcDir) &&
+    fs.existsSync(artifactsDir)
+  ) {
+    console.info('Sysimage build already done', SYSIMAGE_LOCATION);
     return;
   }
 
-  fs.rmSync(DEPOT_LOCATION, {
-    force: true,
-    recursive: true,
-  });
+  // Start from a clean slate for every output and temp dir.
+  for (const p of [
+    SYSIMAGE_LOCATION,
+    PLUTO_SOURCE_LOCATION,
+    SERVER_DEPOT_LOCATION,
+    BUILD_DEPOT_LOCATION,
+    BUILD_TOOLS_DEPOT_LOCATION,
+    BUILD_TOOLS_ENV_LOCATION,
+  ]) {
+    fs.rmSync(p, { force: true, recursive: true });
+  }
 
-  const projectPath = path.join(projectRoot, 'assets', 'env_for_julia');
-  console.log('prepareJuliaDepot: Project path:', projectPath);
-  console.log('prepareJuliaDepot: Spawning Julia process...');
-
-  // Stack the depots that ship inside the Julia installation behind the depot
-  // we are building, exactly like the app does at runtime (see
-  // getServerDepotPath in src/plutoProcess.ts). The packages precompiled here
-  // record the build_ids of the stdlib caches they were compiled against;
-  // with a single-entry JULIA_DEPOT_PATH, Julia would compile its own stdlib
-  // caches into this depot instead of using the ones shipped with Julia, and
-  // every cache we ship would then be rejected on user machines ("module X is
-  // already loaded and incompatible").
+  const envProject = path.join(projectRoot, 'assets', 'env_for_julia');
   const juliaRootDir = path.join(generatedAssetsDir, JULIA_DIR_NAME);
-  const depotStack = [
-    DEPOT_LOCATION,
+  // The depots inside the Julia install must be stacked so instantiate/build
+  // reuse the stdlib caches and JLL artifacts that ship with Julia (see the
+  // depot-stacking rationale in git history), and so JLLs that ARE bundled with
+  // Julia don't get their artifacts re-downloaded into our shipped depot.
+  const shareDepots = [
     path.join(juliaRootDir, 'local', 'share', 'julia'),
     path.join(juliaRootDir, 'share', 'julia'),
-  ].join(path.delimiter);
+  ];
+  const buildNotebooksDir = path.join(os.tmpdir(), 'pluto_desktop_build_notebooks');
 
-  const res = spawn(
+  // 1. Instantiate env_for_julia into the build depot. This downloads Pluto, its
+  //    dependencies, and their (non-bundled) artifacts. Pluto's precompile
+  //    workload runs here; keep its sample notebook out of the tree.
+  console.log('buildPlutoSysimage: instantiating env_for_julia...');
+  await runJulia(
     julia_path,
-    [
-      `--project=${projectPath}`,
-      `-e`,
-      `import Pkg; Pkg.instantiate(); import Pluto`,
-    ],
+    [`--project=${envProject}`, '-e', 'import Pkg; Pkg.instantiate()'],
     {
-      env: {
-        ...process.env,
-        JULIA_DEPOT_PATH: depotStack,
-        // Pluto's precompile workload creates a sample notebook in
-        // first(DEPOT_PATH)/pluto_notebooks unless this is set; keep that out
-        // of the shipped depot.
-        JULIA_PLUTO_NEW_NOTEBOOKS_DIR: path.join(
-          os.tmpdir(),
-          'pluto_desktop_build_notebooks',
-        ),
-      },
+      JULIA_DEPOT_PATH: [BUILD_DEPOT_LOCATION, ...shareDepots].join(path.delimiter),
+      JULIA_PLUTO_NEW_NOTEBOOKS_DIR: buildNotebooksDir,
     },
   );
 
-  // Handle stdout to prevent buffer overflow
-  res.stdout.on('data', (data) => {
-    process.stdout.write(data?.toString?.());
-  });
+  // 2. Install PackageCompiler into a SEPARATE tools depot, so it and the mingw
+  //    toolchain it downloads never end up among the shipped artifacts.
+  console.log('buildPlutoSysimage: installing PackageCompiler...');
+  fs.mkdirSync(BUILD_TOOLS_ENV_LOCATION, { recursive: true });
+  fs.writeFileSync(
+    path.join(BUILD_TOOLS_ENV_LOCATION, 'Project.toml'),
+    `[deps]\nPackageCompiler = "${PACKAGE_COMPILER_UUID}"\n`,
+  );
+  await runJulia(
+    julia_path,
+    [`--project=${BUILD_TOOLS_ENV_LOCATION}`, '-e', 'import Pkg; Pkg.instantiate()'],
+    {
+      JULIA_DEPOT_PATH: [BUILD_TOOLS_DEPOT_LOCATION, ...shareDepots].join(
+        path.delimiter,
+      ),
+    },
+  );
 
-  // Handle stderr
-  res.stderr.on('data', (data) => {
-    process.stderr.write(data?.toString?.());
-  });
-
-  // Handle spawn errors
-  res.on('error', (error) => {
-    console.error('prepareJuliaDepot: Failed to spawn Julia process:', error);
-    throw error;
-  });
-
-  console.log('prepareJuliaDepot: Waiting for Julia process to complete...');
-  const exit_code = await new Promise((resolve) => {
-    res.once('close', (code) => {
-      console.log('prepareJuliaDepot: Julia process exited with code:', code);
-      resolve(code);
-    });
-  });
-
-  if (exit_code !== 0) {
-    console.error('DEPOT preparation failed with exit code:', exit_code);
-    throw new Error(`DEPOT preparation failed with exit code: ${exit_code}`);
+  // 3. Build the sysimage. The driver runs with the tools project (for
+  //    PackageCompiler); it compiles the Pluto env, resolved from the build
+  //    depot. cpu_target is left at PackageCompiler's default, which is already
+  //    a portable multi-arch target.
+  console.log('buildPlutoSysimage: creating sysimage (this takes a while)...');
+  const buildScript = [
+    'using PackageCompiler',
+    `create_sysimage(["Pluto"]; sysimage_path=raw"${SYSIMAGE_LOCATION}", project=raw"${envProject}", incremental=true)`,
+  ].join('\n');
+  await runJulia(
+    julia_path,
+    [`--project=${BUILD_TOOLS_ENV_LOCATION}`, '-e', buildScript],
+    {
+      JULIA_DEPOT_PATH: [
+        BUILD_TOOLS_DEPOT_LOCATION,
+        BUILD_DEPOT_LOCATION,
+        ...shareDepots,
+      ].join(path.delimiter),
+      JULIA_PLUTO_NEW_NOTEBOOKS_DIR: buildNotebooksDir,
+    },
+  );
+  if (!fs.existsSync(SYSIMAGE_LOCATION)) {
+    throw new Error(`Sysimage was not produced at ${SYSIMAGE_LOCATION}`);
   }
 
-  // Remove build-machine artifacts from the shipped depot:
-  //  - registries: not needed to run an already-instantiated environment
-  //    (large, and the runtime never resolves)
-  //  - logs, scratchspaces: per-machine state; Julia only ever consults them
-  //    in the first depot of the stack, which at runtime is the user's depot
-  for (const junk of ['registries', 'logs', 'scratchspaces']) {
-    fs.rmSync(path.join(DEPOT_LOCATION, junk), {
-      force: true,
-      recursive: true,
-    });
+  // 4. Extract Pluto's own source (frontend/, src/, sample/, …) so PLUTO_LOCATION
+  //    resolves at runtime. Drop dev-only trees we don't ship.
+  const plutoPackages = path.join(BUILD_DEPOT_LOCATION, 'packages', 'Pluto');
+  const plutoHashes = fs.readdirSync(plutoPackages);
+  if (plutoHashes.length !== 1) {
+    throw new Error(
+      `Expected exactly one Pluto package dir in ${plutoPackages}, found: ${plutoHashes.join(', ')}`,
+    );
+  }
+  const plutoBuildSrc = path.join(plutoPackages, plutoHashes[0]);
+  const skip = new Set(['test', 'frontend-bundler', '.git']);
+  fs.mkdirSync(PLUTO_SOURCE_LOCATION, { recursive: true });
+  fs.cpSync(plutoBuildSrc, plutoSrcDir, {
+    recursive: true,
+    filter: (src) => {
+      const rel = path.relative(plutoBuildSrc, src);
+      const top = rel.split(path.sep)[0];
+      return !skip.has(top);
+    },
+  });
+  console.info('Extracted Pluto source to', plutoSrcDir);
+
+  // 5. Ship an artifacts-only depot: the JLL binaries Pluto's deps resolve at
+  //    runtime whose versions differ from the ones bundled with Julia.
+  fs.mkdirSync(SERVER_DEPOT_LOCATION, { recursive: true });
+  const buildArtifacts = path.join(BUILD_DEPOT_LOCATION, 'artifacts');
+  if (fs.existsSync(buildArtifacts)) {
+    fs.cpSync(buildArtifacts, artifactsDir, { recursive: true });
+    console.info('Extracted JLL artifacts to', artifactsDir);
+  } else {
+    // No non-bundled artifacts were needed; ship an empty artifacts dir so the
+    // runtime depot stack entry is valid.
+    fs.mkdirSync(artifactsDir, { recursive: true });
   }
 
-  // Fix file permissions on macOS to prevent code signing issues
-  if (platform === 'darwin') {
-    // (🤖🤖 This if block is AI written and not reviewed.)
-    try {
-      // First, make files writable so we can remove extended attributes
-      execSync(`find "${DEPOT_LOCATION}" -type f -exec chmod u+w {} +`, {
-        stdio: 'ignore',
-      });
-      execSync(`find "${DEPOT_LOCATION}" -type d -exec chmod u+w {} +`, {
-        stdio: 'ignore',
-      });
-      // Remove extended attributes (quarantine, etc.) that can interfere with code signing
-      execSync(`xattr -rc "${DEPOT_LOCATION}" 2>/dev/null || true`, {
-        stdio: 'ignore',
-      });
-      // Set final correct permissions: 644 for files, 755 for directories
-      execSync(`find "${DEPOT_LOCATION}" -type f -exec chmod 644 {} +`, {
-        stdio: 'ignore',
-      });
-      execSync(`find "${DEPOT_LOCATION}" -type d -exec chmod 755 {} +`, {
-        stdio: 'ignore',
-      });
-      console.info(
-        'Fixed file permissions and removed extended attributes in DEPOT',
-      );
-    } catch (error) {
-      console.warn('Warning: Could not fix file permissions:', error.message);
-    }
+  // 6. Remove the (large) build-only depots.
+  for (const p of [
+    BUILD_DEPOT_LOCATION,
+    BUILD_TOOLS_DEPOT_LOCATION,
+    BUILD_TOOLS_ENV_LOCATION,
+  ]) {
+    fs.rmSync(p, { force: true, recursive: true });
   }
 
-  console.info('DEPOT preparation success', DEPOT_LOCATION);
+  fixupMacPermissions(PLUTO_SOURCE_LOCATION);
+  fixupMacPermissions(SERVER_DEPOT_LOCATION);
+
+  console.info('Sysimage build success', SYSIMAGE_LOCATION);
 };
 
 /**  (🤖🤖 This function is AI written and not reviewed.) */
@@ -418,8 +441,8 @@ export default async (config, platform, arch) => {
   let files = fs.readdirSync(generatedAssetsDir);
 
   // Clean up after a Julia version change: findJulia() at runtime picks the
-  // first julia-* directory it sees, and a depot built with another Julia
-  // holds useless caches.
+  // first julia-* directory it sees, and a sysimage built with another Julia is
+  // incompatible.
   const staleJulias = files.filter(
     (s) => /^julia-\d+\.\d+\.\d+$/.test(s) && s !== JULIA_DIR_NAME,
   );
@@ -431,12 +454,24 @@ export default async (config, platform, arch) => {
         force: true,
       });
     }
-    console.log('Removing julia_depot built with a previous Julia...');
-    fs.rmSync(path.join(generatedAssetsDir, DEPOT_NAME), {
-      recursive: true,
-      force: true,
-    });
+    // The sysimage, its extracted Pluto source, and the artifacts depot were
+    // built against the previous Julia; force a rebuild.
+    console.log('Removing sysimage build outputs from a previous Julia...');
+    for (const p of [
+      SYSIMAGE_LOCATION,
+      PLUTO_SOURCE_LOCATION,
+      SERVER_DEPOT_LOCATION,
+    ]) {
+      fs.rmSync(p, { recursive: true, force: true });
+    }
     files = fs.readdirSync(generatedAssetsDir);
+  }
+
+  // Remove the old full depot from the pre-sysimage design if it's lying around.
+  const legacyDepot = path.join(generatedAssetsDir, 'julia_depot');
+  if (fs.existsSync(legacyDepot)) {
+    console.log('Removing legacy julia_depot (superseded by the sysimage)...');
+    fs.rmSync(legacyDepot, { recursive: true, force: true });
   }
 
   if (!files.includes(JULIA_DIR_NAME)) {
@@ -451,12 +486,7 @@ export default async (config, platform, arch) => {
     JULIA_EXECUTABLE,
   );
 
-  await prepareJuliaDepot({
+  await buildPlutoSysimage({
     julia_path: juliaPath,
   });
-
-  // NOT DOING THIS, see https://github.com/JuliaPluto/PlutoDesktop/issues/56
-  // await precompilePluto({
-  //   julia_path: juliaPath,
-  // });
 };

--- a/scripts/setPlutoVersion.mjs
+++ b/scripts/setPlutoVersion.mjs
@@ -80,10 +80,10 @@ if (compatSection) {
 fs.writeFileSync(projectTomlPath, toml);
 console.log(`Pinned ${compatLine} in ${path.relative(projectRoot, projectTomlPath)}`);
 
-// Update the Manifest so Pkg.instantiate() at build time installs the new version.
-// Prefer the Julia bundled in generated_assets (same version as the shipped app),
-// fall back to `julia` on the PATH. This uses the user's default depot, which has
-// registries available (the generated_assets depot has them stripped).
+// Update the Manifest so the build-time instantiate/sysimage build uses the new
+// version. Prefer the Julia bundled in generated_assets (same version as the
+// shipped app), fall back to `julia` on the PATH. This uses the user's default
+// depot, which has the registry available to re-resolve.
 const findJulia = () => {
   const exe = process.platform === 'win32' ? 'julia.exe' : 'julia';
   if (fs.existsSync(generatedAssetsDir)) {
@@ -120,12 +120,23 @@ if (res.status !== 0) {
   process.exit(res.status ?? 1);
 }
 
-// The prepared depot caches the previously installed Pluto; remove it so the
-// next `npm run make` reinstalls with the new Manifest.
-const depotPath = path.join(generatedAssetsDir, 'julia_depot');
-if (fs.existsSync(depotPath)) {
-  console.log('Removing generated_assets/julia_depot so the next build uses the new Pluto...');
-  fs.rmSync(depotPath, { recursive: true, force: true });
+// The sysimage build outputs are built from the previous Pluto; remove them so
+// the next `npm run make` rebuilds the sysimage (and re-extracts the source and
+// artifacts) from the new Manifest. generateAssets.js skips the build when these
+// already exist, so a stale sysimage would otherwise silently ship the old Pluto.
+const staleBuildOutputs = [
+  'pluto_sysimage.dll',
+  'pluto_sysimage.so',
+  'pluto_sysimage.dylib',
+  'pluto_source',
+  'pluto_server_depot',
+];
+for (const name of staleBuildOutputs) {
+  const p = path.join(generatedAssetsDir, name);
+  if (fs.existsSync(p)) {
+    console.log(`Removing generated_assets/${name} so the next build uses the new Pluto...`);
+    fs.rmSync(p, { recursive: true, force: true });
+  }
 }
 
 console.log(`Done! PlutoDesktop is now version ${newVersion}, bundling Pluto v${plutoVersion}.`);

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -25,9 +25,26 @@ export const getGeneratedAssetPath = (...paths: string[]): string => {
   return path.join(GENERATED_ASSETS_PATH, ...paths);
 };
 
-// The bundled, read-only Julia depot, prepared at build time
-// (scripts/generateAssets.js). It contains the package sources and precompile
-// caches needed to launch the Pluto server, and is only ever read: everything
-// Pluto installs for notebooks goes to the user's normal depot (see
-// getServerDepotPath in plutoProcess.ts).
-export const BUNDLED_DEPOT_LOCATION = getGeneratedAssetPath('julia_depot');
+// The Pluto server sysimage, built at build time (scripts/generateAssets.js).
+// Launching `julia --sysimage=<this>` gives the server Pluto and all its
+// dependencies precompiled, so it needs no depot packages, no precompilation,
+// and works offline. Notebook workers keep using the DEFAULT Julia sysimage.
+const SYSIMAGE_BASENAME =
+  process.platform === 'win32'
+    ? 'pluto_sysimage.dll'
+    : process.platform === 'darwin'
+      ? 'pluto_sysimage.dylib'
+      : 'pluto_sysimage.so';
+export const PLUTO_SYSIMAGE_LOCATION = getGeneratedAssetPath(SYSIMAGE_BASENAME);
+
+// The small, read-only depot shipped alongside the sysimage. It holds only the
+// JLL binary artifacts the server needs at runtime (e.g. MbedTLS_jll) whose
+// versions differ from the ones bundled with Julia — no package sources and no
+// precompile caches (those are in the sysimage). Stacked read-only behind the
+// user's depot; everything Pluto installs for notebooks goes to the user depot.
+export const PLUTO_SERVER_DEPOT_LOCATION = getGeneratedAssetPath('pluto_server_depot');
+
+// Pluto's own package source, extracted from the build at build time. Needed on
+// disk so PLUTO_LOCATION (used by the file:// frontend, see src/pluto.ts) and
+// Base.locate_package resolve. The Pluto *module* itself comes from the sysimage.
+export const PLUTO_SOURCE_LOCATION = getGeneratedAssetPath('pluto_source', 'Pluto');

--- a/src/plutoProcess.ts
+++ b/src/plutoProcess.ts
@@ -6,7 +6,8 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
-  BUNDLED_DEPOT_LOCATION,
+  PLUTO_SERVER_DEPOT_LOCATION,
+  PLUTO_SOURCE_LOCATION,
   getAssetPath,
   getGeneratedAssetPath,
 } from './paths.ts';
@@ -51,17 +52,18 @@ export const findJulia = () => {
  *     that everything Pluto installs for notebooks — packages, registries,
  *     precompile caches — goes to the same place as in a plain Julia session,
  *     and nothing accumulates in app-managed directories.
- *  2. The bundled read-only depot, which provides the package sources and
- *     precompile caches to launch the Pluto server itself, offline and
- *     without recompilation.
- *  3. The two depots inside the Julia installation, which provide the
- *     precompile caches for the standard libraries. Julia includes these by
+ *  2. The bundled read-only server depot, which holds only the JLL binary
+ *     artifacts the server needs at runtime (Pluto and its dependencies come
+ *     from the sysimage, so there are no package sources or precompile caches
+ *     here).
+ *  3. The two depots inside the Julia installation, which provide the standard
+ *     library caches and Julia's bundled JLL artifacts. Julia includes these by
  *     default, but setting JULIA_DEPOT_PATH replaces the whole stack, so they
  *     must be listed explicitly.
  *
- * Note that notebook processes don't use this stack: the server resets
- * JULIA_DEPOT_PATH to the user's original value before spawning them (see
- * run_pluto.jl).
+ * Notebook (worker) processes inherit this stack, but launch with the DEFAULT
+ * Julia sysimage (see run_pluto.jl / Malt) and install everything they need
+ * into the user's depot, which is first.
  */
 export const getServerDepotPath = (): string => {
   const juliaRoot = path.dirname(path.dirname(findJulia()));
@@ -70,7 +72,7 @@ export const getServerDepotPath = (): string => {
     : path.join(os.homedir(), '.julia');
   return [
     userDepots,
-    BUNDLED_DEPOT_LOCATION,
+    PLUTO_SERVER_DEPOT_LOCATION,
     path.join(juliaRoot, 'local', 'share', 'julia'),
     path.join(juliaRoot, 'share', 'julia'),
   ].join(path.delimiter);
@@ -81,6 +83,17 @@ export function findPluto(): Promise<string> {
   return new Promise((resolve, reject) => {
     if (_plutoLocation !== null) resolve(String(_plutoLocation));
 
+    // Normal (packaged) case: the Pluto source is shipped next to the sysimage
+    // (scripts/generateAssets.js). We know exactly where it is, so there's no
+    // need to ask Julia — this also avoids a Julia subprocess at startup.
+    if (fs.existsSync(PLUTO_SOURCE_LOCATION)) {
+      _plutoLocation = PLUTO_SOURCE_LOCATION;
+      resolve(_plutoLocation);
+      return;
+    }
+
+    // Dev fallback: no shipped source (e.g. SKIP_GENERATE_ASSETS). Ask Julia
+    // where Pluto is via locate_pluto.jl.
     const juliaCmd = findJulia();
     let resolved = false;
 

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { generalLogger, juliaLogger } from './logger.ts';
-import { getAssetPath } from './paths.ts';
+import { getAssetPath, PLUTO_SYSIMAGE_LOCATION } from './paths.ts';
 import {
   findJulia,
   findPluto,
@@ -33,13 +33,20 @@ export async function startup(app: App, loadingUrl: string) {
   // returns Chromium's canonical form (`file:///C:/...`). Normalize so the
   // comparison below works in both development and production.
   const normalizedLoadingUrl = new URL(loadingUrl).href;
-  const SYSIMAGE_LOCATION = getAssetPath('pluto.so');
 
   const options = [`--project=${plutoProject}`];
-  if (fs.existsSync(SYSIMAGE_LOCATION)) {
-    options.push(`--sysimage=${SYSIMAGE_LOCATION}`);
+  if (fs.existsSync(PLUTO_SYSIMAGE_LOCATION)) {
+    // The Pluto server image (scripts/generateAssets.js). It has Pluto and all
+    // its dependencies precompiled, so the server starts fast, offline, and
+    // without touching a depot. Notebook workers ignore it and use the default
+    // sysimage (Malt launches them with just the julia executable path).
+    options.push(`--sysimage=${PLUTO_SYSIMAGE_LOCATION}`);
     generalLogger.info(
-      `System image found at ${SYSIMAGE_LOCATION}. Julia will use this instead of the default`,
+      `System image found at ${PLUTO_SYSIMAGE_LOCATION}. Julia will use this instead of the default`,
+    );
+  } else {
+    generalLogger.warn(
+      `No Pluto sysimage at ${PLUTO_SYSIMAGE_LOCATION}; starting Pluto without one (slower; dev only).`,
     );
   }
 


### PR DESCRIPTION
## What & why

A **different approach** to the same goals as #132 (offline launch, no growing
app-managed depot, userland on the normal global depot). We got stuck making the
bundled **depot** robust — the shipped precompile caches invalidate on
relocation and the depot accumulates. This PR ships Pluto compiled into a
**sysimage** instead.

The Pluto server launches with `julia --sysimage=…`, so it needs **no
precompilation and makes no writes to any app-managed directory**, and starts
faster. Notebook **workers keep using the default Julia sysimage** automatically,
so userland code is unaffected.

> [!NOTE]
> Stacked on `julia-1.12-depot-stacking` (#132) — the base branch — so this diff
> is only the sysimage-specific changes on top of the shared Julia-1.12 bundling
> work. Draft: opening for review of the approach.

Full write-up (investigation, experiments, decisions, validation) is in
[`SYSIMAGE_INVESTIGATION.md`](SYSIMAGE_INVESTIGATION.md), added in this PR.

## How it works

`generated_assets/` now ships:

| item | size | purpose |
|---|---|---|
| `julia-<ver>/` | (unchanged) | Julia install — provides the **default** sysimage for notebook workers |
| `pluto_sysimage.<dll\|so\|dylib>` | ~410 MB | Pluto + all deps compiled in; the server image |
| `pluto_source/Pluto/` | ~25 MB | Pluto's own source, so `PLUTO_LOCATION` / the `file://` frontend resolve |
| `pluto_server_depot/artifacts/` | ~16 MB | only the JLL binary artifacts whose versions differ from Julia's bundled ones (e.g. MbedTLS_jll) |

No package sources, no `compiled/` precompile caches — those are all in the
sysimage. Pluto's `frontend/`, `src/runner/`, `sample/` are embedded in the
sysimage via RelocatableFolders and re-materialize into a scratchspace in the
**user** depot on first launch.

Why workers stay on the default sysimage: Malt starts them with just the Julia
executable path (`Base.julia_cmd()[1]`, not the parent's `-J`), and Pluto's
`SYSIMAGE_DEFAULT = nothing`, so no `--sysimage` is passed. `PlutoRunner`
(stdlib-only deps) precompiles into the user's depot, exactly like a plain Julia
session.

## Changes

- **`scripts/generateAssets.js`** — new `buildPlutoSysimage` replacing
  `prepareJuliaDepot`/`precompilePluto`: instantiate `env_for_julia` into a temp
  build depot, build the sysimage with PackageCompiler in a **separate** tools
  depot (so its ~700 MB mingw toolchain never reaches the shipped artifacts),
  extract the Pluto source + JLL artifacts, delete the temp depots.
- **`src/paths.ts`** — `PLUTO_SYSIMAGE_LOCATION` / `PLUTO_SERVER_DEPOT_LOCATION`
  / `PLUTO_SOURCE_LOCATION` replace `BUNDLED_DEPOT_LOCATION`.
- **`src/plutoProcess.ts`** — `getServerDepotPath` stacks the artifacts-only
  server depot; `findPluto` returns the shipped source directly (keeps
  `locate_pluto.jl` as a dev/no-sysimage fallback).
- **`src/startup.ts`** — `--sysimage` points at the built image (was a hardcoded
  `assets/pluto.so`).
- **`assets/run_pluto.jl`**, **`scripts/setPlutoVersion.mjs`**, **`MAINTENANCE.md`**
  — updated for the new layout.
- **`env_for_julia` and `set-pluto-version` are unchanged** — verified the
  server starts from the sysimage using the existing checked-in Manifest.

## Validation (real artifacts, Windows)

- Build → 410 MB sysimage + 25 MB source + 16 MB artifacts; temp depots cleaned.
- Server launched from the shipped sysimage with a **fresh empty user depot** +
  the production depot stack → **HTTP 200 on `/` and `/edit` in ~5 s** (vs ~15 s).
- Worker test: **server on `pluto_sysimage.dll`, worker on the default
  `sys.dll`**, worker's env in the user depot.
- **Full Electron app** (`npm run start:inspect`): logs show the sysimage in use,
  `Pluto found at …pluto_source\Pluto`, and `Entry url found`.

## Open questions before this could ship

1. **Installer size** — the ~410 MB image makes `PlutoSetup.exe` and each
   `-full.nupkg` much larger, and Squirrel ships a full copy per update (no
   deltas). This is the main trade-off vs the depot approach.
2. **Offline first-notebook on a fresh machine** — the worker installed the
   General registry when bootstrapping `PlutoRunner`; wants a dedicated offline
   test (shared with the depot approach, not new here).
3. macOS/Linux builds not yet exercised (paths + basenames are handled; only
   Windows was validated locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
