### PR TITLE
Enable Squirrel delta (patch) updates

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -39,6 +39,8 @@ const config: ForgeConfig = {
       // Shown in Windows "Apps & features"; must be a URL, not a local path.
       iconUrl:
         'https://raw.githubusercontent.com/JuliaPluto/PlutoDesktop/main/assets/icon.ico',
+      remoteReleases:
+        'https://github.com/JuliaPluto/PlutoDesktop/releases/latest/download',
     }),
     new MakerZIP({}, ['darwin']),
     new MakerRpm({}),


### PR DESCRIPTION
_Generated by AI 🤖_

Sets `remoteReleases` on the Squirrel maker so the Windows build downloads the previous release and diffs against it, producing a `-delta.nupkg` alongside the full package.

### Why this is all that's needed
- Squirrel's `--releasify` generates deltas **by default** (`noDelta` would turn them off).
- `remoteReleases` is the missing piece: the build runs `SyncReleases.exe` to fetch the previous `RELEASES` + `-full.nupkg`, then diffs against it (bsdiff per binary).
- `maker-squirrel` only adds the `-delta.nupkg` to its uploaded artifacts **when `remoteReleases` is set**, so this one option enables both generation and shipping.
- The auto-updater (`update-electron-app` → update.electronjs.org → Squirrel `Update.exe`) applies deltas with **no client change**.

### Expected payoff (uneven, due to the large bundled binaries)
| Release type | Delta size |
|---|---|
| Desktop-only (buildNNN bump, same Pluto+Julia) | tiny — big win (550 MB → ~MB) |
| Pluto version bump (recompiled sysimage) | uncertain — bsdiff on a relinked native image may not shrink much |
| Julia version bump | ~full package, falls back to full |

### To verify on Windows (couldn't test on macOS — Squirrel/bsdiff are Windows exes)
- Build doesn't OOM/hang while bsdiff'ing the ~527 MB `pluto_sysimage.dll` (needs ~9 GB RAM; `windows-latest` has 16 GB).
- A small `-delta.nupkg` lands in `out/make/squirrel.windows/x64/`.
- An installed copy updates via the delta.

The first release after this merges produces no delta (nothing to diff against yet); it kicks in from the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)